### PR TITLE
feat: v0.5.0–v0.7.0 — smart zoom, short metadata, frame descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.7.0] - 2026-03-23
+
+### Added
+
+- Player name, assists, event type, and team level now passed as context to short title/description prompt templates (`{{player}}`, `{{assists}}`, `{{event}}`, `{{team_level}}`)
+- Bundled prompt templates updated with player/event/level fields for richer AI-generated metadata
+
+## [0.6.0] - 2026-03-23
+
+### Added
+
+- `POST_RENDER` hook handler — generates LLM-powered title and description for short/rendered video uploads via `short_metadata_enabled` config flag
+- `short_metadata.py` module with `ShortMetadata` model and `generate_short_metadata()` function
+- Bundled prompt templates: `short_title.txt` and `short_description.txt`
+- `short_metadata_enabled` config field (default `false`) — opt-in LLM metadata for shorts
+- Game info cached during `ON_GAME_INIT` for use in `POST_RENDER` metadata generation
+- Writes `short_title` and `short_description` to `context.shared["uploads"]["google"]` for Google plugin consumption
+- Frame description generation (`frames.py`) — analyze all extracted frames via OpenAI vision to generate per-frame descriptions and overall play summary
+- `frame_description_enabled` and `frame_description_model` config fields
+- Bundled prompt template: `frame_describe`
+- Frame descriptions cached on plugin instance and fed as `{{frame_summary}}` context to short metadata prompts
+- Frame descriptions written to `context.shared["frame_descriptions"]` with `descriptions` list and `summary`
+
+## [0.5.0] - 2026-03-20
+
+### Added
+
+- Smart zoom target detection (`zoom.py`) — analyze video frames via OpenAI vision API to identify action areas for dynamic crop panning
+- `ON_FRAMES_EXTRACTED` hook handler — iterates extracted frames, calls vision API per frame, writes `ZoomPath` to `context.shared["smart_zoom"]`
+- `smart_zoom_enabled` and `smart_zoom_model` config fields
+- Bundled prompt template: `smart_zoom_detect`
+- Vision support on `request_structured()` — optional `images` and `model_override` keyword arguments for sending base64 images with structured JSON requests
+- Per-frame fallback to center `(0.5, 0.5)` on API failure; no shared write when all frames fail
+
 ## [0.4.2] - 2026-03-15
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_PKG := reeln_openai_plugin
 
-.PHONY: dev-install test lint format check
+.PHONY: dev-install install test lint format check
 
 VENV := .venv/bin
 
@@ -8,6 +8,9 @@ dev-install:
 	uv venv --clear
 	uv pip install -e ../reeln-cli
 	uv pip install -e ".[dev]"
+
+install:
+	uv pip install --python ~/.local/share/uv/tools/reeln/bin/python3 -e .
 
 test:
 	$(VENV)/python -m pytest tests/ -n auto --cov=$(PLUGIN_PKG) --cov-branch --cov-fail-under=100 -q

--- a/docs/smart-zoom-requirements.md
+++ b/docs/smart-zoom-requirements.md
@@ -1,0 +1,302 @@
+# Smart Zoom — Plugin Requirements
+
+This document defines the contract between reeln-cli core and the openai plugin
+for the smart target zoom feature. The core handles frame extraction and filter
+graph building; the plugin handles vision analysis.
+
+## Overview
+
+When a user renders a short with `--crop smart`, reeln-cli:
+
+1. Extracts N frames from the input clip (via `Renderer.extract_frames`)
+2. Emits `ON_FRAMES_EXTRACTED` hook with the frame paths and video metadata
+3. Reads `context.shared["smart_zoom"]["zoom_path"]` after the hook returns
+4. Builds a dynamic ffmpeg crop filter that pans across the detected targets
+
+The plugin's job is step 2→3: analyze the frames and write the zoom path.
+
+## Hook: ON_FRAMES_EXTRACTED
+
+### When it fires
+
+After frame extraction completes, before the render filter chain is built.
+This hook fires during `reeln render short` and `reeln render preview` when
+`crop_mode` is `smart`.
+
+### context.data (read-only)
+
+```python
+from pathlib import Path
+from reeln.models.zoom import ExtractedFrames
+
+{
+    "frames": ExtractedFrames(
+        frame_paths=(Path("/tmp/.../frame_0001.png"), ...),
+        timestamps=(1.0, 3.0, 5.0, 7.0, 9.0),
+        source_width=1920,
+        source_height=1080,
+        duration=10.0,
+        fps=59.94,
+    ),
+    "input_path": Path("/path/to/clip.mkv"),
+    "crop_mode": "smart",
+}
+```
+
+### context.shared (write)
+
+The plugin writes zoom targets here. Core reads them after `emit()` returns.
+
+```python
+from reeln.models.zoom import ZoomPath, ZoomPoint
+
+context.shared["smart_zoom"] = {
+    "zoom_path": ZoomPath(
+        points=(
+            ZoomPoint(timestamp=1.0, center_x=0.3, center_y=0.4, confidence=0.95),
+            ZoomPoint(timestamp=3.0, center_x=0.35, center_y=0.42, confidence=0.90),
+            ZoomPoint(timestamp=5.0, center_x=0.5, center_y=0.45, confidence=0.88),
+            ZoomPoint(timestamp=7.0, center_x=0.6, center_y=0.5, confidence=0.92),
+            ZoomPoint(timestamp=9.0, center_x=0.7, center_y=0.48, confidence=0.91),
+        ),
+        source_width=1920,
+        source_height=1080,
+        duration=10.0,
+    ),
+}
+```
+
+### Optional: frame descriptions (dual use)
+
+The same extracted frames can also be used to generate a clip description.
+This is a separate concern from zoom targeting but shares the same hook.
+
+```python
+context.shared["frame_descriptions"] = {
+    "descriptions": [
+        "Player #7 carries the puck through the neutral zone",
+        "Shot on goal from the left circle",
+        "Goalie makes a glove save",
+        "Rebound play in front of the net",
+        "Puck cleared to the corner",
+    ],
+    "summary": "Fast break leading to a shot and save sequence",
+}
+```
+
+This is a future extension — zoom is the priority. But design the handler
+so adding description generation later is straightforward (separate feature flag,
+separate API call, same frames).
+
+## Data Models (from reeln-cli)
+
+These are defined in `reeln/models/zoom.py` and imported by the plugin:
+
+```python
+from reeln.models.zoom import ExtractedFrames, ZoomPath, ZoomPoint
+```
+
+### ZoomPoint
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | `float` | Seconds into the clip |
+| `center_x` | `float` | 0.0 (left) to 1.0 (right) |
+| `center_y` | `float` | 0.0 (top) to 1.0 (bottom) |
+| `confidence` | `float` | 0.0-1.0, detection confidence (default 1.0) |
+
+### ZoomPath
+| Field | Type | Description |
+|-------|------|-------------|
+| `points` | `tuple[ZoomPoint, ...]` | Ordered by timestamp |
+| `source_width` | `int` | Original video width |
+| `source_height` | `int` | Original video height |
+| `duration` | `float` | Total clip duration in seconds |
+
+### ExtractedFrames
+| Field | Type | Description |
+|-------|------|-------------|
+| `frame_paths` | `tuple[Path, ...]` | PNG frame file paths |
+| `timestamps` | `tuple[float, ...]` | Timestamp of each frame |
+| `source_width` | `int` | Video width |
+| `source_height` | `int` | Video height |
+| `duration` | `float` | Clip duration |
+| `fps` | `float` | Video frame rate |
+
+## Plugin Implementation
+
+### New config fields
+
+```python
+ConfigField(
+    name="smart_zoom_enabled",
+    field_type="bool",
+    default=False,
+    description="Enable smart zoom target detection via OpenAI vision",
+),
+ConfigField(
+    name="smart_zoom_model",
+    field_type="str",
+    default="gpt-4.1",
+    description="OpenAI model for smart zoom vision analysis",
+),
+```
+
+Prompt override is already supported via the existing `prompt_overrides` config.
+
+### New hook registration
+
+```python
+def register(self, registry: HookRegistry) -> None:
+    registry.register(Hook.ON_GAME_INIT, self.on_game_init)
+    registry.register(Hook.ON_FRAMES_EXTRACTED, self.on_frames_extracted)
+```
+
+### Handler skeleton
+
+```python
+def on_frames_extracted(self, context: HookContext) -> None:
+    """Analyze extracted frames for zoom targets."""
+    if not self._config.get("smart_zoom_enabled", False):
+        return
+
+    frames: ExtractedFrames = context.data["frames"]
+    client = self._get_client()
+
+    points: list[ZoomPoint] = []
+    for frame_path, timestamp in zip(frames.frame_paths, frames.timestamps):
+        center_x, center_y = analyze_frame_for_zoom(
+            client=client,
+            prompt_registry=self._prompt_registry,
+            frame_path=frame_path,
+            model=str(self._config.get("smart_zoom_model", "gpt-4.1")),
+        )
+        points.append(ZoomPoint(
+            timestamp=timestamp,
+            center_x=center_x,
+            center_y=center_y,
+        ))
+
+    zoom_path = ZoomPath(
+        points=tuple(points),
+        source_width=frames.source_width,
+        source_height=frames.source_height,
+        duration=frames.duration,
+    )
+    context.shared["smart_zoom"] = {"zoom_path": zoom_path}
+```
+
+### New module: `zoom.py`
+
+```python
+def analyze_frame_for_zoom(
+    client: OpenAIClient,
+    prompt_registry: PromptRegistry,
+    frame_path: Path,
+    *,
+    model: str = "gpt-4.1",
+) -> tuple[float, float]:
+    """Send a frame to OpenAI vision and get zoom target coordinates.
+
+    Returns (center_x, center_y) as normalized 0.0-1.0 floats.
+    Falls back to (0.5, 0.5) on failure.
+    """
+```
+
+Uses `client.request_structured()` with the frame as a base64 image input.
+
+### New prompt template: `prompt_templates/smart_zoom_detect.txt`
+
+```
+You are analyzing a frame from a video to identify the main area of action.
+
+Task:
+- Identify the primary subject or action area in the frame.
+- Return the center of that area as normalized coordinates (0.0-1.0).
+- 0.0, 0.0 is the top-left corner; 1.0, 1.0 is the bottom-right corner.
+- If no clear action area is visible, return the center of the frame.
+
+Return JSON only:
+{"center_x": 0.5, "center_y": 0.5}
+```
+
+### Response schema
+
+```python
+ZOOM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "center_x": {"type": "number"},
+        "center_y": {"type": "number"},
+    },
+    "required": ["center_x", "center_y"],
+    "additionalProperties": False,
+}
+```
+
+### Error handling
+
+- API failure on a single frame: log warning, use `(0.5, 0.5)` fallback
+- API failure on all frames: log warning, do NOT write to `context.shared`
+  (core will fall back to static center crop)
+- Clamp returned values to 0.0-1.0
+
+## Testing Requirements
+
+- Mock `OpenAIClient` — never call real API in tests
+- Test feature flag gating (disabled → no API calls, no shared writes)
+- Test with 1 frame, 3 frames, 5 frames
+- Test API failure fallback per-frame
+- Test API failure on all frames (no shared write)
+- Test coordinate clamping (API returns out-of-range values)
+- Test prompt template rendering and override
+- 100% line + branch coverage
+
+## Registry Update
+
+Add `hook:ON_FRAMES_EXTRACTED` to the openai plugin entry in
+`reeln-cli/registry/plugins.json`:
+
+```json
+{
+    "name": "openai",
+    "capabilities": [
+        "hook:ON_GAME_INIT",
+        "hook:ON_FRAMES_EXTRACTED"
+    ]
+}
+```
+
+## Config Profile Example
+
+A user enables smart zoom via their reeln config profile:
+
+```json
+{
+    "render_profiles": {
+        "smart_replay": {
+            "crop_mode": "smart",
+            "smart_zoom_frames": 5
+        }
+    },
+    "plugins": {
+        "settings": {
+            "openai": {
+                "enabled": true,
+                "smart_zoom_enabled": true,
+                "smart_zoom_model": "gpt-4.1"
+            }
+        }
+    }
+}
+```
+
+Usage: `reeln render short clip.mkv --render-profile smart_replay`
+
+## Phasing
+
+This plugin work (Phase 6) can start as soon as Phase 1 (contracts/models) lands
+in reeln-cli. The plugin imports `ZoomPoint`, `ZoomPath`, and `ExtractedFrames`
+from `reeln.models.zoom`, so that module must exist first.
+
+For local development before Phase 1 merges, you can copy the dataclass
+definitions into a local stub or install reeln-cli from the feature branch.

--- a/reeln_openai_plugin/__init__.py
+++ b/reeln_openai_plugin/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.4.2"
+__version__ = "0.7.0"
 
 from reeln_openai_plugin.plugin import OpenAIPlugin
 

--- a/reeln_openai_plugin/client.py
+++ b/reeln_openai_plugin/client.py
@@ -48,13 +48,24 @@ class OpenAIClient:
         prompt: str,
         schema: dict[str, Any],
         schema_name: str,
+        *,
+        images: list[str] | None = None,
+        model_override: str | None = None,
     ) -> dict[str, Any]:
         """Send a text prompt and return the parsed JSON response.
 
         The API is instructed to return JSON conforming to *schema* via the
-        ``json_schema`` response format.
+        ``json_schema`` response format.  When *images* is provided, base64
+        PNG images are prepended as ``input_image`` content blocks.  When
+        *model_override* is set it replaces the client's default model.
         """
-        payload = self._build_payload(prompt, schema, schema_name)
+        payload = self._build_payload(
+            prompt,
+            schema,
+            schema_name,
+            images=images,
+            model_override=model_override,
+        )
         raw = self._post(payload)
         return self._parse_response(raw)
 
@@ -102,13 +113,21 @@ class OpenAIClient:
         prompt: str,
         schema: dict[str, Any],
         schema_name: str,
+        *,
+        images: list[str] | None = None,
+        model_override: str | None = None,
     ) -> dict[str, Any]:
+        content: list[dict[str, str]] = []
+        if images:
+            content.extend({"type": "input_image", "image_url": f"data:image/png;base64,{b64}"} for b64 in images)
+        content.append({"type": "input_text", "text": prompt})
+
         return {
-            "model": self._model,
+            "model": model_override if model_override is not None else self._model,
             "input": [
                 {
                     "role": "user",
-                    "content": [{"type": "input_text", "text": prompt}],
+                    "content": content,
                 },
             ],
             "text": {
@@ -130,8 +149,7 @@ class OpenAIClient:
         output_format: str,
     ) -> dict[str, Any]:
         content: list[dict[str, str]] = [
-            {"type": "input_image", "image_url": f"data:image/png;base64,{b64}"}
-            for b64 in images
+            {"type": "input_image", "image_url": f"data:image/png;base64,{b64}"} for b64 in images
         ]
         content.append({"type": "input_text", "text": prompt})
 
@@ -182,7 +200,10 @@ class OpenAIClient:
         raise OpenAIError("No image output found in API response")
 
     def _post(
-        self, payload: dict[str, Any], *, timeout: float | None = None,
+        self,
+        payload: dict[str, Any],
+        *,
+        timeout: float | None = None,
     ) -> dict[str, Any]:
         """POST *payload* to the OpenAI API and return the parsed response."""
         effective_timeout = timeout if timeout is not None else self._timeout

--- a/reeln_openai_plugin/frames.py
+++ b/reeln_openai_plugin/frames.py
@@ -1,0 +1,65 @@
+"""Frame description generation via OpenAI vision API."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from reeln_openai_plugin.client import OpenAIClient
+from reeln_openai_plugin.prompts import PromptRegistry
+from reeln_openai_plugin.zoom import _encode_frame
+
+log: logging.Logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FrameDescriptions:
+    """Per-frame descriptions and an overall play summary."""
+
+    descriptions: tuple[str, ...]
+    summary: str
+
+
+FRAME_DESCRIPTION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "descriptions": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "summary": {"type": "string"},
+    },
+    "required": ["descriptions", "summary"],
+    "additionalProperties": False,
+}
+
+
+def describe_frames(
+    client: OpenAIClient,
+    prompt_registry: PromptRegistry,
+    frame_paths: tuple[Path, ...],
+    *,
+    model: str = "gpt-4.1",
+) -> FrameDescriptions:
+    """Send all frames to OpenAI vision in a single call and get descriptions.
+
+    Returns a :class:`FrameDescriptions` with per-frame descriptions and
+    an overall summary.  Raises :class:`OpenAIError` on failure.
+    """
+    images = [_encode_frame(p) for p in frame_paths]
+    prompt = prompt_registry.render("frame_describe")
+
+    result = client.request_structured(
+        prompt=prompt,
+        schema=FRAME_DESCRIPTION_SCHEMA,
+        schema_name="frame_descriptions",
+        images=images,
+        model_override=model,
+    )
+
+    return FrameDescriptions(
+        descriptions=tuple(result["descriptions"]),
+        summary=result["summary"],
+    )

--- a/reeln_openai_plugin/plugin.py
+++ b/reeln_openai_plugin/plugin.py
@@ -9,15 +9,19 @@ from pathlib import Path
 from typing import Any
 
 from reeln.models.plugin_schema import ConfigField, PluginConfigSchema
+from reeln.models.zoom import ExtractedFrames, ZoomPath, ZoomPoint
 from reeln.plugins.hooks import Hook, HookContext
 from reeln.plugins.registry import HookRegistry
 
 from reeln_openai_plugin.client import OpenAIClient, OpenAIError
+from reeln_openai_plugin.frames import FrameDescriptions, describe_frames
 from reeln_openai_plugin.game_image import generate_game_image
 from reeln_openai_plugin.livestream import generate_livestream_metadata
 from reeln_openai_plugin.playlist import generate_playlist_metadata
 from reeln_openai_plugin.prompts import PromptRegistry
+from reeln_openai_plugin.short_metadata import generate_short_metadata
 from reeln_openai_plugin.translate import translate_metadata
+from reeln_openai_plugin.zoom import FALLBACK_CENTER, analyze_frame_for_zoom
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -31,7 +35,7 @@ class OpenAIPlugin:
     """
 
     name: str = "openai"
-    version: str = "0.4.2"
+    version: str = "0.7.0"
     api_version: int = 1
 
     config_schema: PluginConfigSchema = PluginConfigSchema(
@@ -121,12 +125,44 @@ class OpenAIPlugin:
                 default="",
                 description="Directory to save generated game images",
             ),
+            ConfigField(
+                name="short_metadata_enabled",
+                field_type="bool",
+                default=False,
+                description="Enable LLM-generated title and description for short uploads",
+            ),
+            ConfigField(
+                name="smart_zoom_enabled",
+                field_type="bool",
+                default=False,
+                description="Enable smart zoom target detection via OpenAI vision",
+            ),
+            ConfigField(
+                name="smart_zoom_model",
+                field_type="str",
+                default="gpt-4.1",
+                description="OpenAI model for smart zoom vision analysis",
+            ),
+            ConfigField(
+                name="frame_description_enabled",
+                field_type="bool",
+                default=False,
+                description="Enable frame description generation via OpenAI vision",
+            ),
+            ConfigField(
+                name="frame_description_model",
+                field_type="str",
+                default="gpt-4.1",
+                description="OpenAI model for frame description generation",
+            ),
         )
     )
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         self._config: dict[str, Any] = config or {}
         self._client: OpenAIClient | None = None
+        self._game_info: object | None = None
+        self._frame_descriptions: FrameDescriptions | None = None
 
         # Parse JSON string configs
         self._prompt_overrides: dict[str, str] = self._parse_json_config("prompt_overrides")
@@ -144,6 +180,8 @@ class OpenAIPlugin:
     def register(self, registry: HookRegistry) -> None:
         """Register hook handlers with the reeln plugin registry."""
         registry.register(Hook.ON_GAME_INIT, self.on_game_init)
+        registry.register(Hook.POST_RENDER, self.on_post_render)
+        registry.register(Hook.ON_FRAMES_EXTRACTED, self.on_frames_extracted)
 
     def on_game_init(self, context: HookContext) -> None:
         """Handle ``ON_GAME_INIT`` — generate livestream metadata."""
@@ -154,6 +192,8 @@ class OpenAIPlugin:
         if game_info is None:
             log.warning("%s plugin: no game_info in context, skipping", self.name)
             return
+
+        self._game_info = game_info
 
         home_profile = context.data.get("home_profile")
         away_profile = context.data.get("away_profile")
@@ -194,7 +234,9 @@ class OpenAIPlugin:
         """Generate livestream metadata via LLM and optionally translate."""
         try:
             metadata = generate_livestream_metadata(
-                client, self._prompt_registry, game_info,
+                client,
+                self._prompt_registry,
+                game_info,
                 home_profile=home_profile,
                 away_profile=away_profile,
             )
@@ -218,8 +260,7 @@ class OpenAIPlugin:
                     per_language_prompts=self._per_language_prompts or None,
                 )
                 result["translations"] = {
-                    code: {"title": t.title, "description": t.description}
-                    for code, t in translations.items()
+                    code: {"title": t.title, "description": t.description} for code, t in translations.items()
                 }
             except OpenAIError as exc:
                 log.warning("%s plugin: translation failed: %s", self.name, exc)
@@ -263,8 +304,7 @@ class OpenAIPlugin:
                     per_language_prompts=self._per_language_prompts or None,
                 )
                 playlist_result["translations"] = {
-                    code: {"title": t.title, "description": t.description}
-                    for code, t in playlist_translations.items()
+                    code: {"title": t.title, "description": t.description} for code, t in playlist_translations.items()
                 }
             except OpenAIError as exc:
                 log.warning("%s plugin: playlist translation failed: %s", self.name, exc)
@@ -287,7 +327,9 @@ class OpenAIPlugin:
             return
 
         if not getattr(home_profile, "logo_path", None) or not getattr(
-            away_profile, "logo_path", None,
+            away_profile,
+            "logo_path",
+            None,
         ):
             log.warning("%s plugin: missing team logos for game image, skipping", self.name)
             return
@@ -316,6 +358,190 @@ class OpenAIPlugin:
             log.info("%s plugin: generated game image: %s", self.name, image_result.image_path)
         except OpenAIError as exc:
             log.warning("%s plugin: game image generation failed: %s", self.name, exc)
+
+    def on_post_render(self, context: HookContext) -> None:
+        """Handle ``POST_RENDER`` — generate short title and description."""
+        if not self._config.get("short_metadata_enabled", False):
+            return
+
+        # game_info may be cached from ON_GAME_INIT (same process) or passed
+        # through the hook data (separate CLI invocation like render short).
+        game_info = self._game_info or context.data.get("game_info")
+        if game_info is None:
+            log.debug("%s plugin: no game_info available, skipping short metadata", self.name)
+            return
+
+        plan = context.data.get("plan")
+        if plan is None:
+            return
+
+        # Only enrich renders that have a filter chain (shorts/applies with filters)
+        if getattr(plan, "filter_complex", None) is None:
+            return
+
+        try:
+            client = self._get_client()
+        except OpenAIError as exc:
+            log.warning("%s plugin: client setup failed: %s", self.name, exc)
+            return
+
+        clip_name = getattr(getattr(plan, "output", None), "stem", "")
+
+        frame_summary = ""
+        if self._frame_descriptions is not None:
+            frame_summary = self._frame_descriptions.summary
+            self._frame_descriptions = None
+
+        # Extract event context from hook data
+        player_name = context.data.get("player", "")
+        assists_str = context.data.get("assists", "")
+        game_event = context.data.get("game_event")
+        event_type = getattr(game_event, "event_type", "") if game_event else ""
+        level = getattr(game_info, "level", "")
+
+        try:
+            metadata = generate_short_metadata(
+                client,
+                self._prompt_registry,
+                game_info,
+                clip_name=clip_name,
+                frame_summary=frame_summary,
+                player=player_name,
+                assists=assists_str,
+                event_type=event_type,
+                level=level,
+            )
+        except OpenAIError as exc:
+            log.warning("%s plugin: short metadata generation failed: %s", self.name, exc)
+            return
+
+        context.shared["uploads"] = context.shared.get("uploads", {})
+        google = context.shared["uploads"].setdefault("google", {})
+        google["short_title"] = metadata.title
+        google["short_description"] = metadata.description
+        log.info("%s plugin: generated short metadata: %s", self.name, metadata.title)
+
+    def on_frames_extracted(self, context: HookContext) -> None:
+        """Handle ``ON_FRAMES_EXTRACTED`` — analyze frames for zoom targets and describe frames."""
+        smart_zoom_enabled = self._config.get("smart_zoom_enabled", False)
+        frame_desc_enabled = self._config.get("frame_description_enabled", False)
+
+        if not smart_zoom_enabled and not frame_desc_enabled:
+            return
+
+        frames_data = context.data.get("frames")
+        if frames_data is None:
+            log.warning("%s plugin: no frames in context, skipping", self.name)
+            return
+
+        frames: ExtractedFrames = frames_data
+
+        if not frames.frame_paths:
+            log.warning("%s plugin: empty frame list, skipping", self.name)
+            return
+
+        try:
+            client = self._get_client()
+        except OpenAIError as exc:
+            log.warning("%s plugin: client setup failed: %s", self.name, exc)
+            return
+
+        if smart_zoom_enabled:
+            zoom_path = self._analyze_frames_for_zoom(client, frames)
+            if zoom_path is not None:
+                context.shared["smart_zoom"] = {"zoom_path": zoom_path}
+
+        if frame_desc_enabled:
+            self._describe_frames(client, frames, context)
+
+    def _analyze_frames_for_zoom(
+        self,
+        client: OpenAIClient,
+        frames: ExtractedFrames,
+    ) -> ZoomPath | None:
+        """Analyze each frame and return a :class:`ZoomPath`, or ``None`` on total failure."""
+        model = str(self._config.get("smart_zoom_model", "gpt-4.1"))
+        points: list[ZoomPoint] = []
+        success_count = 0
+
+        for frame_path, timestamp in zip(frames.frame_paths, frames.timestamps, strict=True):
+            try:
+                center_x, center_y = analyze_frame_for_zoom(
+                    client=client,
+                    prompt_registry=self._prompt_registry,
+                    frame_path=frame_path,
+                    model=model,
+                )
+                success_count += 1
+            except OpenAIError as exc:
+                log.warning(
+                    "%s plugin: frame %s analysis failed, using fallback: %s",
+                    self.name,
+                    frame_path,
+                    exc,
+                )
+                center_x, center_y = FALLBACK_CENTER
+
+            points.append(
+                ZoomPoint(
+                    timestamp=timestamp,
+                    center_x=center_x,
+                    center_y=center_y,
+                ),
+            )
+
+        if success_count == 0:
+            log.warning(
+                "%s plugin: all %d frame analyses failed, not writing zoom path",
+                self.name,
+                len(frames.frame_paths),
+            )
+            return None
+
+        log.info(
+            "%s plugin: smart zoom analysis complete — %d/%d frames succeeded",
+            self.name,
+            success_count,
+            len(frames.frame_paths),
+        )
+
+        return ZoomPath(
+            points=tuple(points),
+            source_width=frames.source_width,
+            source_height=frames.source_height,
+            duration=frames.duration,
+        )
+
+    def _describe_frames(
+        self,
+        client: OpenAIClient,
+        frames: ExtractedFrames,
+        context: HookContext,
+    ) -> None:
+        """Generate frame descriptions and cache for POST_RENDER use."""
+        model = str(self._config.get("frame_description_model", "gpt-4.1"))
+        try:
+            descriptions = describe_frames(
+                client=client,
+                prompt_registry=self._prompt_registry,
+                frame_paths=frames.frame_paths,
+                model=model,
+            )
+        except OpenAIError as exc:
+            log.warning("%s plugin: frame description failed: %s", self.name, exc)
+            return
+
+        self._frame_descriptions = descriptions
+        context.shared["frame_descriptions"] = {
+            "descriptions": list(descriptions.descriptions),
+            "summary": descriptions.summary,
+        }
+        log.info(
+            "%s plugin: described %d frames — %s",
+            self.name,
+            len(descriptions.descriptions),
+            descriptions.summary[:80],
+        )
 
     def _get_client(self) -> OpenAIClient:
         """Lazily create and return the :class:`OpenAIClient`.

--- a/reeln_openai_plugin/prompt_templates/frame_describe.txt
+++ b/reeln_openai_plugin/prompt_templates/frame_describe.txt
@@ -1,0 +1,11 @@
+You are analyzing a sequence of frames from a video highlight clip.
+The frames are in chronological order.
+
+Task:
+- Describe what happens in each frame in 1-2 sentences.
+- Then provide a brief summary of the overall play (1-2 sentences).
+- Focus on the action, movement, and outcome.
+- Keep descriptions concise and energetic.
+
+Return JSON with:
+{"descriptions": ["Frame 1 description", ...], "summary": "Overall summary"}

--- a/reeln_openai_plugin/prompt_templates/short_description.txt
+++ b/reeln_openai_plugin/prompt_templates/short_description.txt
@@ -1,0 +1,22 @@
+You are writing a short YouTube Shorts description for a {{sport}} highlight clip.
+
+Teams: {{home_team}} vs {{away_team}}
+Date: {{date}}
+Venue: {{venue}}
+Level: {{team_level}}
+Event: {{event}}
+Player: {{player}}
+Assists: {{assists}}
+Clip: {{clip_name}}
+Context: {{description}}
+Frame analysis: {{frame_summary}}
+
+Rules:
+- 1-3 sentences max — Shorts descriptions are rarely read in full.
+- Mention both teams.
+- If the player name is available, mention them by name.
+- Include relevant hashtags at the end (e.g. #hockey #highlights).
+- Keep it family friendly and enthusiastic.
+- If venue is provided, mention it.
+
+Return a JSON object with a "description" key.

--- a/reeln_openai_plugin/prompt_templates/short_title.txt
+++ b/reeln_openai_plugin/prompt_templates/short_title.txt
@@ -1,0 +1,21 @@
+You are generating a concise YouTube Shorts title for a {{sport}} highlight clip.
+
+Teams: {{home_team}} vs {{away_team}}
+Date: {{date}}
+Level: {{team_level}}
+Event: {{event}}
+Player: {{player}}
+Assists: {{assists}}
+Clip: {{clip_name}}
+Context: {{description}}
+Frame analysis: {{frame_summary}}
+
+Rules:
+- Max 100 characters (YouTube truncates long titles on Shorts).
+- Include both team names.
+- Include the player name if available.
+- Make it attention-grabbing and suitable for short-form vertical video.
+- Do not include "#Shorts" — it will be appended automatically.
+- Do not include hashtags.
+
+Return a JSON object with a "title" key.

--- a/reeln_openai_plugin/prompt_templates/smart_zoom_detect.txt
+++ b/reeln_openai_plugin/prompt_templates/smart_zoom_detect.txt
@@ -1,0 +1,10 @@
+You are analyzing a frame from a video to identify the main area of action.
+
+Task:
+- Identify the primary subject or action area in the frame.
+- Return the center of that area as normalized coordinates (0.0-1.0).
+- 0.0, 0.0 is the top-left corner; 1.0, 1.0 is the bottom-right corner.
+- If no clear action area is visible, return the center of the frame.
+
+Return JSON only:
+{"center_x": 0.5, "center_y": 0.5}

--- a/reeln_openai_plugin/short_metadata.py
+++ b/reeln_openai_plugin/short_metadata.py
@@ -1,0 +1,88 @@
+"""Short video title and description generation via OpenAI."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from reeln_openai_plugin.client import OpenAIClient
+from reeln_openai_plugin.livestream import build_prompt_variables
+from reeln_openai_plugin.prompts import PromptRegistry
+
+log: logging.Logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ShortMetadata:
+    """Generated short video title and description."""
+
+    title: str
+    description: str
+
+
+SHORT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "description": {"type": "string"},
+    },
+    "required": ["title", "description"],
+    "additionalProperties": False,
+}
+
+
+def generate_short_metadata(
+    client: OpenAIClient,
+    prompt_registry: PromptRegistry,
+    game_info: object,
+    clip_name: str = "",
+    frame_summary: str = "",
+    player: str = "",
+    assists: str = "",
+    event_type: str = "",
+    level: str = "",
+) -> ShortMetadata:
+    """Generate a short video title and description from *game_info*.
+
+    Renders the ``short_title`` and ``short_description`` prompts,
+    combines them into a single API call, and returns the structured result.
+
+    When *clip_name* is provided it is included as a template variable
+    so the LLM can incorporate the clip identifier.
+    """
+    variables = build_prompt_variables(game_info)
+
+    if clip_name:
+        variables["clip_name"] = clip_name
+
+    if frame_summary:
+        variables["frame_summary"] = frame_summary
+
+    if player:
+        variables["player"] = player
+
+    if assists:
+        variables["assists"] = assists
+
+    if event_type:
+        variables["event"] = event_type
+
+    if level:
+        variables["team_level"] = level
+
+    title_prompt = prompt_registry.render("short_title", variables)
+    desc_prompt = prompt_registry.render("short_description", variables)
+
+    combined_prompt = f"{title_prompt}\n\n---\n\n{desc_prompt}"
+
+    result = client.request_structured(
+        prompt=combined_prompt,
+        schema=SHORT_SCHEMA,
+        schema_name="short",
+    )
+
+    return ShortMetadata(
+        title=result["title"],
+        description=result["description"],
+    )

--- a/reeln_openai_plugin/translate.py
+++ b/reeln_openai_plugin/translate.py
@@ -74,7 +74,12 @@ def translate_metadata(
 
     if per_language_prompts:
         return _translate_per_language(
-            client, prompt_registry, title, description, languages, per_language_prompts,
+            client,
+            prompt_registry,
+            title,
+            description,
+            languages,
+            per_language_prompts,
         )
     return _translate_batch(client, prompt_registry, title, description, languages)
 

--- a/reeln_openai_plugin/zoom.py
+++ b/reeln_openai_plugin/zoom.py
@@ -1,0 +1,65 @@
+"""Smart zoom target detection via OpenAI vision API."""
+
+from __future__ import annotations
+
+import base64
+import logging
+from pathlib import Path
+from typing import Any
+
+from reeln_openai_plugin.client import OpenAIClient, OpenAIError
+from reeln_openai_plugin.prompts import PromptRegistry
+
+log: logging.Logger = logging.getLogger(__name__)
+
+ZOOM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "center_x": {"type": "number"},
+        "center_y": {"type": "number"},
+    },
+    "required": ["center_x", "center_y"],
+    "additionalProperties": False,
+}
+
+FALLBACK_CENTER: tuple[float, float] = (0.5, 0.5)
+
+
+def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    """Clamp *value* to the range [*low*, *high*]."""
+    return max(low, min(high, value))
+
+
+def _encode_frame(frame_path: Path) -> str:
+    """Read a frame file and return its base64-encoded contents."""
+    try:
+        raw = frame_path.read_bytes()
+    except OSError as exc:
+        raise OpenAIError(f"Cannot read frame file {frame_path}: {exc}") from exc
+    return base64.b64encode(raw).decode()
+
+
+def analyze_frame_for_zoom(
+    client: OpenAIClient,
+    prompt_registry: PromptRegistry,
+    frame_path: Path,
+    *,
+    model: str = "gpt-4.1",
+) -> tuple[float, float]:
+    """Send a frame to OpenAI vision and get zoom target coordinates.
+
+    Returns ``(center_x, center_y)`` as normalized 0.0-1.0 floats.
+    Raises :class:`OpenAIError` on failure — caller decides fallback.
+    """
+    b64_image = _encode_frame(frame_path)
+    prompt = prompt_registry.render("smart_zoom_detect")
+    result = client.request_structured(
+        prompt,
+        ZOOM_SCHEMA,
+        "smart_zoom_detect",
+        images=[b64_image],
+        model_override=model,
+    )
+    center_x = _clamp(float(result["center_x"]))
+    center_y = _clamp(float(result["center_y"]))
+    return (center_x, center_y)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +22,19 @@ class FakeGameInfo:
     game_time: str = ""
     description: str = ""
     thumbnail: str = ""
+    level: str = ""
+
+
+@dataclass
+class FakeGameEvent:
+    """Minimal stand-in for ``reeln.models.game.GameEvent``."""
+
+    id: str = "evt-001"
+    clip: str = "clip.mp4"
+    segment_number: int = 1
+    event_type: str = "goal"
+    player: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -40,6 +53,18 @@ class FakeTeamInfo:
     logo_path: Path | None = None
     colors: str = "Red, White"
     game_level: str = "Varsity"
+
+
+@dataclass
+class FakeExtractedFrames:
+    """Minimal stand-in for ``reeln.models.zoom.ExtractedFrames``."""
+
+    frame_paths: tuple[Path, ...] = ()
+    timestamps: tuple[float, ...] = ()
+    source_width: int = 1920
+    source_height: int = 1080
+    duration: float = 10.0
+    fps: float = 59.94
 
 
 @pytest.fixture()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -25,6 +25,7 @@ class TestRepr:
         assert "[REDACTED]" in r
         assert "gpt-test" in r
 
+
 # ------------------------------------------------------------------
 # read_api_key
 # ------------------------------------------------------------------
@@ -54,11 +55,66 @@ class TestBuildPayload:
 
         assert payload["model"] == "gpt-test"
         assert payload["input"][0]["role"] == "user"
+        # Text-only: single content block
+        assert len(payload["input"][0]["content"]) == 1
         assert payload["input"][0]["content"][0]["type"] == "input_text"
         assert payload["input"][0]["content"][0]["text"] == "hello"
         assert payload["text"]["format"]["type"] == "json_schema"
         assert payload["text"]["format"]["name"] == "test_schema"
         assert payload["text"]["format"]["schema"] is schema
+
+    def test_backward_compat_no_images(self) -> None:
+        """Calling without images/model_override produces text-only payload."""
+        client = OpenAIClient(api_key="k", model="gpt-test")
+        schema: dict[str, Any] = {"type": "object", "properties": {}}
+        payload = client._build_payload("hi", schema, "s")
+        content = payload["input"][0]["content"]
+        assert len(content) == 1
+        assert content[0]["type"] == "input_text"
+        assert payload["model"] == "gpt-test"
+
+    def test_with_images(self) -> None:
+        client = OpenAIClient(api_key="k", model="gpt-test")
+        schema: dict[str, Any] = {"type": "object", "properties": {}}
+        payload = client._build_payload(
+            "analyze",
+            schema,
+            "zoom",
+            images=["b64_frame1", "b64_frame2"],
+        )
+        content = payload["input"][0]["content"]
+        assert len(content) == 3
+        assert content[0]["type"] == "input_image"
+        assert content[0]["image_url"] == "data:image/png;base64,b64_frame1"
+        assert content[1]["type"] == "input_image"
+        assert content[1]["image_url"] == "data:image/png;base64,b64_frame2"
+        assert content[2]["type"] == "input_text"
+        assert content[2]["text"] == "analyze"
+
+    def test_model_override(self) -> None:
+        client = OpenAIClient(api_key="k", model="gpt-default")
+        schema: dict[str, Any] = {"type": "object", "properties": {}}
+        payload = client._build_payload(
+            "p",
+            schema,
+            "s",
+            model_override="gpt-vision",
+        )
+        assert payload["model"] == "gpt-vision"
+
+    def test_model_override_none_uses_default(self) -> None:
+        client = OpenAIClient(api_key="k", model="gpt-default")
+        schema: dict[str, Any] = {"type": "object", "properties": {}}
+        payload = client._build_payload("p", schema, "s", model_override=None)
+        assert payload["model"] == "gpt-default"
+
+    def test_empty_images_list(self) -> None:
+        client = OpenAIClient(api_key="k", model="gpt-test")
+        schema: dict[str, Any] = {"type": "object", "properties": {}}
+        payload = client._build_payload("p", schema, "s", images=[])
+        content = payload["input"][0]["content"]
+        assert len(content) == 1
+        assert content[0]["type"] == "input_text"
 
 
 # ------------------------------------------------------------------
@@ -279,8 +335,12 @@ class TestBuildImagePayload:
     def test_no_images(self) -> None:
         client = OpenAIClient(api_key="k")
         payload = client._build_image_payload(
-            prompt="p", images=[], model="m", renderer_model="r",
-            renderer_size="s", output_format="png",
+            prompt="p",
+            images=[],
+            model="m",
+            renderer_model="r",
+            renderer_size="s",
+            output_format="png",
         )
         content = payload["input"][0]["content"]
         assert len(content) == 1

--- a/tests/unit/test_frames.py
+++ b/tests/unit/test_frames.py
@@ -1,0 +1,178 @@
+"""Tests for frame description generation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from reeln_openai_plugin.client import OpenAIError
+from reeln_openai_plugin.frames import (
+    FRAME_DESCRIPTION_SCHEMA,
+    FrameDescriptions,
+    describe_frames,
+)
+from reeln_openai_plugin.prompts import PromptRegistry
+
+# ------------------------------------------------------------------
+# FrameDescriptions
+# ------------------------------------------------------------------
+
+
+class TestFrameDescriptions:
+    def test_frozen(self) -> None:
+        fd = FrameDescriptions(descriptions=("a",), summary="s")
+        with pytest.raises(AttributeError):
+            fd.summary = "x"  # type: ignore[misc]
+
+    def test_fields(self) -> None:
+        fd = FrameDescriptions(descriptions=("a", "b"), summary="s")
+        assert fd.descriptions == ("a", "b")
+        assert fd.summary == "s"
+
+    def test_empty_descriptions(self) -> None:
+        fd = FrameDescriptions(descriptions=(), summary="nothing")
+        assert fd.descriptions == ()
+        assert fd.summary == "nothing"
+
+
+# ------------------------------------------------------------------
+# FRAME_DESCRIPTION_SCHEMA
+# ------------------------------------------------------------------
+
+
+class TestFrameDescriptionSchema:
+    def test_required_fields(self) -> None:
+        assert set(FRAME_DESCRIPTION_SCHEMA["required"]) == {"descriptions", "summary"}
+
+    def test_no_additional_properties(self) -> None:
+        assert FRAME_DESCRIPTION_SCHEMA["additionalProperties"] is False
+
+    def test_descriptions_is_array_of_strings(self) -> None:
+        desc_prop = FRAME_DESCRIPTION_SCHEMA["properties"]["descriptions"]
+        assert desc_prop["type"] == "array"
+        assert desc_prop["items"]["type"] == "string"
+
+    def test_summary_is_string(self) -> None:
+        assert FRAME_DESCRIPTION_SCHEMA["properties"]["summary"]["type"] == "string"
+
+
+# ------------------------------------------------------------------
+# describe_frames
+# ------------------------------------------------------------------
+
+
+class TestDescribeFrames:
+    def test_success(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "descriptions": ["Player shoots", "Goalie dives", "Goal scored"],
+            "summary": "A quick wrist shot finds the top corner.",
+        }
+        registry = PromptRegistry()
+        frames = tuple(self._make_frames(tmp_path, 3))
+
+        result = describe_frames(client, registry, frames)
+
+        assert isinstance(result, FrameDescriptions)
+        assert len(result.descriptions) == 3
+        assert result.descriptions[0] == "Player shoots"
+        assert result.summary == "A quick wrist shot finds the top corner."
+
+        call_kwargs = client.request_structured.call_args[1]
+        assert call_kwargs["schema_name"] == "frame_descriptions"
+        assert len(call_kwargs["images"]) == 3
+
+    def test_api_error_propagates(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        client.request_structured.side_effect = OpenAIError("API down")
+        registry = PromptRegistry()
+        frames = tuple(self._make_frames(tmp_path, 1))
+
+        with pytest.raises(OpenAIError, match="API down"):
+            describe_frames(client, registry, frames)
+
+    def test_model_override(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "descriptions": ["action"],
+            "summary": "summary",
+        }
+        registry = PromptRegistry()
+        frames = tuple(self._make_frames(tmp_path, 1))
+
+        describe_frames(client, registry, frames, model="gpt-5")
+
+        call_kwargs = client.request_structured.call_args[1]
+        assert call_kwargs["model_override"] == "gpt-5"
+
+    def test_uses_default_model(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "descriptions": ["action"],
+            "summary": "summary",
+        }
+        registry = PromptRegistry()
+        frames = tuple(self._make_frames(tmp_path, 1))
+
+        describe_frames(client, registry, frames)
+
+        call_kwargs = client.request_structured.call_args[1]
+        assert call_kwargs["model_override"] == "gpt-4.1"
+
+    def test_single_frame(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "descriptions": ["A save is made"],
+            "summary": "Goaltender makes a save.",
+        }
+        registry = PromptRegistry()
+        frames = tuple(self._make_frames(tmp_path, 1))
+
+        result = describe_frames(client, registry, frames)
+
+        assert len(result.descriptions) == 1
+        assert result.summary == "Goaltender makes a save."
+
+    def test_renders_frame_describe_prompt(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "descriptions": ["d"],
+            "summary": "s",
+        }
+        registry = PromptRegistry()
+        frames = tuple(self._make_frames(tmp_path, 1))
+
+        describe_frames(client, registry, frames)
+
+        call_kwargs = client.request_structured.call_args[1]
+        assert "chronological order" in call_kwargs["prompt"]
+
+    def test_encodes_frames_as_base64(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "descriptions": ["d1", "d2"],
+            "summary": "s",
+        }
+        registry = PromptRegistry()
+        frames = tuple(self._make_frames(tmp_path, 2))
+
+        describe_frames(client, registry, frames)
+
+        call_kwargs = client.request_structured.call_args[1]
+        images = call_kwargs["images"]
+        assert len(images) == 2
+        # base64 of b"\x89PNG" should be a non-empty string
+        for img in images:
+            assert isinstance(img, str)
+            assert len(img) > 0
+
+    @staticmethod
+    def _make_frames(tmp_path: Path, count: int) -> list[Path]:
+        paths = []
+        for i in range(count):
+            p = tmp_path / f"frame_{i:04d}.png"
+            p.write_bytes(b"\x89PNG")
+            paths.append(p)
+        return paths

--- a/tests/unit/test_playlist.py
+++ b/tests/unit/test_playlist.py
@@ -81,7 +81,10 @@ class TestGeneratePlaylistMetadata:
         info = FakeGameInfo()
 
         result = generate_playlist_metadata(
-            client, registry, info, livestream_title="Live: Eagles vs Hawks",
+            client,
+            registry,
+            info,
+            livestream_title="Live: Eagles vs Hawks",
         )
 
         assert result.title == "Playlist Title"

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -12,7 +12,7 @@ from reeln.plugins.hooks import Hook, HookContext
 from reeln.plugins.registry import HookRegistry
 
 from reeln_openai_plugin.plugin import OpenAIPlugin
-from tests.conftest import FakeGameInfo, FakeTeamInfo
+from tests.conftest import FakeExtractedFrames, FakeGameInfo, FakeTeamInfo
 
 # ------------------------------------------------------------------
 # Attributes
@@ -26,7 +26,7 @@ class TestPluginAttributes:
 
     def test_version(self) -> None:
         plugin = OpenAIPlugin()
-        assert plugin.version == "0.4.2"
+        assert plugin.version == "0.7.0"
 
     def test_api_version(self) -> None:
         plugin = OpenAIPlugin()
@@ -57,6 +57,20 @@ class TestPluginConfigSchema:
         assert "game_image_renderer_model" in names
         assert "game_image_output_dir" in names
 
+    def test_has_short_metadata_field(self) -> None:
+        names = [f.name for f in OpenAIPlugin.config_schema.fields]
+        assert "short_metadata_enabled" in names
+
+    def test_has_smart_zoom_fields(self) -> None:
+        names = [f.name for f in OpenAIPlugin.config_schema.fields]
+        assert "smart_zoom_enabled" in names
+        assert "smart_zoom_model" in names
+
+    def test_has_frame_description_fields(self) -> None:
+        names = [f.name for f in OpenAIPlugin.config_schema.fields]
+        assert "frame_description_enabled" in names
+        assert "frame_description_model" in names
+
     def test_defaults(self) -> None:
         defaults = OpenAIPlugin.config_schema.defaults_dict()
         assert defaults["enabled"] is False
@@ -67,6 +81,11 @@ class TestPluginConfigSchema:
         assert defaults["game_image_model"] == "gpt-5.2"
         assert defaults["game_image_renderer_model"] == "gpt-image-1.5"
         assert defaults["game_image_output_dir"] == ""
+        assert defaults["short_metadata_enabled"] is False
+        assert defaults["smart_zoom_enabled"] is False
+        assert defaults["smart_zoom_model"] == "gpt-4.1"
+        assert defaults["frame_description_enabled"] is False
+        assert defaults["frame_description_model"] == "gpt-4.1"
 
 
 # ------------------------------------------------------------------
@@ -122,6 +141,18 @@ class TestPluginRegister:
         plugin.register(registry)
         assert registry.has_handlers(Hook.ON_GAME_INIT)
 
+    def test_registers_post_render(self) -> None:
+        plugin = OpenAIPlugin()
+        registry = HookRegistry()
+        plugin.register(registry)
+        assert registry.has_handlers(Hook.POST_RENDER)
+
+    def test_registers_on_frames_extracted(self) -> None:
+        plugin = OpenAIPlugin()
+        registry = HookRegistry()
+        plugin.register(registry)
+        assert registry.has_handlers(Hook.ON_FRAMES_EXTRACTED)
+
     def test_does_not_register_other_hooks(self) -> None:
         plugin = OpenAIPlugin()
         registry = HookRegistry()
@@ -152,7 +183,9 @@ class TestOnGameInit:
 
     @patch.dict("os.environ", {}, clear=True)
     def test_client_failure_logs_warning(
-        self, caplog: pytest.LogCaptureFixture, tmp_path: Path,
+        self,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path: Path,
     ) -> None:
         """Missing API key file and no env var causes client setup failure."""
         config: dict[str, Any] = {"enabled": True, "api_key_file": str(tmp_path / "missing.txt")}
@@ -279,6 +312,23 @@ class TestOnGameInit:
 
         mock_gen.assert_called_once()
         assert context.shared["livestream_metadata"]["title"] == "Semis!"
+
+    @patch("reeln_openai_plugin.plugin.generate_livestream_metadata")
+    def test_caches_game_info(
+        self,
+        mock_gen: MagicMock,
+        plugin_config: dict[str, Any],
+    ) -> None:
+        from reeln_openai_plugin.livestream import LivestreamMetadata
+
+        mock_gen.return_value = LivestreamMetadata(title="T", description="D")
+        plugin = OpenAIPlugin(plugin_config)
+        game_info = FakeGameInfo(home_team="Storm")
+        context = HookContext(hook=Hook.ON_GAME_INIT, data={"game_info": game_info})
+
+        plugin.on_game_init(context)
+
+        assert plugin._game_info is game_info
 
     @patch("reeln_openai_plugin.plugin.generate_livestream_metadata")
     def test_translate_disabled_no_translations(
@@ -477,6 +527,246 @@ class TestOnGameInitPlaylist:
 
 
 # ------------------------------------------------------------------
+# on_post_render — short metadata
+# ------------------------------------------------------------------
+
+
+class TestOnPostRender:
+    def test_disabled_skips(self, plugin_config: dict[str, Any]) -> None:
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": False})
+        plugin._game_info = FakeGameInfo()
+        plan = MagicMock()
+        plan.filter_complex = "filter"
+        context = HookContext(hook=Hook.POST_RENDER, data={"plan": plan, "result": MagicMock()})
+
+        plugin.on_post_render(context)
+
+        assert "uploads" not in context.shared
+
+    def test_no_game_info_skips(self, plugin_config: dict[str, Any]) -> None:
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": True})
+        # _game_info not set (no game init happened)
+        plan = MagicMock()
+        plan.filter_complex = "filter"
+        context = HookContext(hook=Hook.POST_RENDER, data={"plan": plan, "result": MagicMock()})
+
+        plugin.on_post_render(context)
+
+        assert "uploads" not in context.shared
+
+    def test_no_plan_skips(self, plugin_config: dict[str, Any]) -> None:
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": True})
+        plugin._game_info = FakeGameInfo()
+        context = HookContext(hook=Hook.POST_RENDER, data={"result": MagicMock()})
+
+        plugin.on_post_render(context)
+
+        assert "uploads" not in context.shared
+
+    def test_no_filter_complex_skips(self, plugin_config: dict[str, Any]) -> None:
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": True})
+        plugin._game_info = FakeGameInfo()
+        plan = MagicMock()
+        plan.filter_complex = None
+        context = HookContext(hook=Hook.POST_RENDER, data={"plan": plan, "result": MagicMock()})
+
+        plugin.on_post_render(context)
+
+        assert "uploads" not in context.shared
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_client_failure_warns(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        config: dict[str, Any] = {
+            "short_metadata_enabled": True,
+            "api_key_file": str(tmp_path / "missing.txt"),
+        }
+        plugin = OpenAIPlugin(config)
+        plugin._game_info = FakeGameInfo()
+        plan = MagicMock()
+        plan.filter_complex = "filter"
+        context = HookContext(hook=Hook.POST_RENDER, data={"plan": plan, "result": MagicMock()})
+
+        with caplog.at_level(logging.WARNING):
+            plugin.on_post_render(context)
+
+        assert "client setup failed" in caplog.text
+        assert "uploads" not in context.shared
+
+    @patch("reeln_openai_plugin.plugin.generate_short_metadata")
+    def test_success(
+        self,
+        mock_gen: MagicMock,
+        plugin_config: dict[str, Any],
+    ) -> None:
+        from reeln_openai_plugin.short_metadata import ShortMetadata
+
+        mock_gen.return_value = ShortMetadata(title="Amazing Goal!", description="Great play!")
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": True})
+        plugin._game_info = FakeGameInfo()
+
+        plan = MagicMock()
+        plan.filter_complex = "filter"
+        plan.output = MagicMock()
+        plan.output.stem = "goal_001"
+        context = HookContext(hook=Hook.POST_RENDER, data={"plan": plan, "result": MagicMock()})
+
+        plugin.on_post_render(context)
+
+        assert context.shared["uploads"]["google"]["short_title"] == "Amazing Goal!"
+        assert context.shared["uploads"]["google"]["short_description"] == "Great play!"
+        mock_gen.assert_called_once()
+
+    @patch("reeln_openai_plugin.plugin.generate_short_metadata")
+    def test_passes_clip_name(
+        self,
+        mock_gen: MagicMock,
+        plugin_config: dict[str, Any],
+    ) -> None:
+        from reeln_openai_plugin.short_metadata import ShortMetadata
+
+        mock_gen.return_value = ShortMetadata(title="T", description="D")
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": True})
+        plugin._game_info = FakeGameInfo()
+
+        plan = MagicMock()
+        plan.filter_complex = "filter"
+        plan.output = MagicMock()
+        plan.output.stem = "clip_highlight"
+        context = HookContext(hook=Hook.POST_RENDER, data={"plan": plan, "result": MagicMock()})
+
+        plugin.on_post_render(context)
+
+        call_kwargs = mock_gen.call_args[1]
+        assert call_kwargs["clip_name"] == "clip_highlight"
+
+    @patch("reeln_openai_plugin.plugin.generate_short_metadata")
+    def test_generation_failure_non_fatal(
+        self,
+        mock_gen: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+        plugin_config: dict[str, Any],
+    ) -> None:
+        from reeln_openai_plugin.client import OpenAIError
+
+        mock_gen.side_effect = OpenAIError("API down")
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": True})
+        plugin._game_info = FakeGameInfo()
+
+        plan = MagicMock()
+        plan.filter_complex = "filter"
+        context = HookContext(hook=Hook.POST_RENDER, data={"plan": plan, "result": MagicMock()})
+
+        with caplog.at_level(logging.WARNING):
+            plugin.on_post_render(context)
+
+        assert "short metadata generation failed" in caplog.text
+        assert "uploads" not in context.shared
+
+    @patch("reeln_openai_plugin.plugin.generate_short_metadata")
+    def test_preserves_existing_shared(
+        self,
+        mock_gen: MagicMock,
+        plugin_config: dict[str, Any],
+    ) -> None:
+        """When shared context already has uploads data, short metadata is merged in."""
+        from reeln_openai_plugin.short_metadata import ShortMetadata
+
+        mock_gen.return_value = ShortMetadata(title="T", description="D")
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": True})
+        plugin._game_info = FakeGameInfo()
+
+        plan = MagicMock()
+        plan.filter_complex = "filter"
+        plan.output = MagicMock()
+        plan.output.stem = "clip"
+        context = HookContext(
+            hook=Hook.POST_RENDER,
+            data={"plan": plan, "result": MagicMock()},
+            shared={"uploads": {"google": {"existing": "data"}}},
+        )
+
+        plugin.on_post_render(context)
+
+        google = context.shared["uploads"]["google"]
+        assert google["existing"] == "data"
+        assert google["short_title"] == "T"
+        assert google["short_description"] == "D"
+
+    @patch("reeln_openai_plugin.plugin.generate_short_metadata")
+    def test_uses_game_info_from_hook_data(
+        self,
+        mock_gen: MagicMock,
+        plugin_config: dict[str, Any],
+    ) -> None:
+        """When _game_info is None, fall back to context.data['game_info']."""
+        from reeln_openai_plugin.short_metadata import ShortMetadata
+
+        mock_gen.return_value = ShortMetadata(title="From Hook", description="D")
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": True})
+        assert plugin._game_info is None
+
+        game_info = FakeGameInfo()
+        plan = MagicMock()
+        plan.filter_complex = "filter"
+        plan.output = MagicMock()
+        plan.output.stem = "clip"
+        context = HookContext(
+            hook=Hook.POST_RENDER,
+            data={"plan": plan, "result": MagicMock(), "game_info": game_info},
+        )
+
+        plugin.on_post_render(context)
+
+        assert context.shared["uploads"]["google"]["short_title"] == "From Hook"
+        # Verify the game_info was passed to generate_short_metadata
+        call_args = mock_gen.call_args
+        assert call_args[0][2] is game_info
+
+    @patch("reeln_openai_plugin.plugin.generate_short_metadata")
+    def test_passes_player_and_event_context(
+        self,
+        mock_gen: MagicMock,
+        plugin_config: dict[str, Any],
+    ) -> None:
+        """Player, assists, event_type, and level are forwarded from hook data."""
+        from reeln_openai_plugin.short_metadata import ShortMetadata
+        from tests.conftest import FakeGameEvent
+
+        mock_gen.return_value = ShortMetadata(title="T", description="D")
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": True})
+
+        game_info = FakeGameInfo(level="2016")
+        game_event = FakeGameEvent(event_type="goal")
+        plan = MagicMock()
+        plan.filter_complex = "filter"
+        plan.output = MagicMock()
+        plan.output.stem = "clip"
+        context = HookContext(
+            hook=Hook.POST_RENDER,
+            data={
+                "plan": plan,
+                "result": MagicMock(),
+                "game_info": game_info,
+                "game_event": game_event,
+                "player": "#48 Benjamin Remitz",
+                "assists": "#7 John Smith",
+            },
+        )
+
+        plugin.on_post_render(context)
+
+        call_kwargs = mock_gen.call_args[1]
+        assert call_kwargs["player"] == "#48 Benjamin Remitz"
+        assert call_kwargs["assists"] == "#7 John Smith"
+        assert call_kwargs["event_type"] == "goal"
+        assert call_kwargs["level"] == "2016"
+
+
+# ------------------------------------------------------------------
 # _get_client
 # ------------------------------------------------------------------
 
@@ -498,8 +788,12 @@ class TestGetClient:
         from reeln_openai_plugin.client import OpenAIError
 
         plugin = OpenAIPlugin({"enabled": True})
-        with patch.dict("os.environ", {}, clear=True), pytest.raises(
-            OpenAIError, match="No API key",
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            pytest.raises(
+                OpenAIError,
+                match="No API key",
+            ),
         ):
             plugin._get_client()
 
@@ -516,12 +810,17 @@ class TestGetClient:
         assert client._api_key == "sk-test-key-12345"
 
     def test_missing_file_falls_back_to_env(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture,
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         config: dict[str, Any] = {"api_key_file": str(tmp_path / "missing.txt")}
         plugin = OpenAIPlugin(config)
-        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-fallback"}), caplog.at_level(
-            logging.WARNING,
+        with (
+            patch.dict("os.environ", {"OPENAI_API_KEY": "sk-fallback"}),
+            caplog.at_level(
+                logging.WARNING,
+            ),
         ):
             client = plugin._get_client()
         assert client._api_key == "sk-fallback"
@@ -532,8 +831,12 @@ class TestGetClient:
 
         config: dict[str, Any] = {"api_key_file": str(tmp_path / "missing.txt")}
         plugin = OpenAIPlugin(config)
-        with patch.dict("os.environ", {}, clear=True), pytest.raises(
-            OpenAIError, match="No API key",
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            pytest.raises(
+                OpenAIError,
+                match="No API key",
+            ),
         ):
             plugin._get_client()
 
@@ -808,6 +1111,480 @@ class TestOnGameInitGameImage:
 
         assert "game_image" not in context.shared
         assert "game_image_output_dir not configured" in caplog.text
+
+
+# ------------------------------------------------------------------
+# on_frames_extracted — smart zoom
+# ------------------------------------------------------------------
+
+
+class TestOnFramesExtracted:
+    def _make_frames(self, tmp_path: Path, count: int = 3) -> FakeExtractedFrames:
+        paths = []
+        timestamps = []
+        for i in range(count):
+            p = tmp_path / f"frame_{i:04d}.png"
+            p.write_bytes(b"\x89PNG")
+            paths.append(p)
+            timestamps.append(float(i * 2))
+        return FakeExtractedFrames(
+            frame_paths=tuple(paths),
+            timestamps=tuple(timestamps),
+        )
+
+    def test_disabled_skips(self, plugin_config: dict[str, Any]) -> None:
+        plugin = OpenAIPlugin({**plugin_config, "smart_zoom_enabled": False})
+        frames = FakeExtractedFrames()
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+        plugin.on_frames_extracted(context)
+        assert "smart_zoom" not in context.shared
+
+    def test_no_frames_data_warns(
+        self,
+        plugin_config: dict[str, Any],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        plugin = OpenAIPlugin({**plugin_config, "smart_zoom_enabled": True})
+        context = HookContext(hook=Hook.ON_FRAMES_EXTRACTED, data={})
+        with caplog.at_level(logging.WARNING):
+            plugin.on_frames_extracted(context)
+        assert "no frames in context" in caplog.text
+        assert "smart_zoom" not in context.shared
+
+    def test_empty_frame_list_warns(
+        self,
+        plugin_config: dict[str, Any],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        plugin = OpenAIPlugin({**plugin_config, "smart_zoom_enabled": True})
+        frames = FakeExtractedFrames(frame_paths=(), timestamps=())
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+        with caplog.at_level(logging.WARNING):
+            plugin.on_frames_extracted(context)
+        assert "empty frame list" in caplog.text
+        assert "smart_zoom" not in context.shared
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_client_failure_warns(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        config: dict[str, Any] = {
+            "smart_zoom_enabled": True,
+            "api_key_file": str(tmp_path / "missing.txt"),
+        }
+        plugin = OpenAIPlugin(config)
+        frames = self._make_frames(tmp_path, count=1)
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+        with caplog.at_level(logging.WARNING):
+            plugin.on_frames_extracted(context)
+        assert "client setup failed" in caplog.text
+        assert "smart_zoom" not in context.shared
+
+    @patch("reeln_openai_plugin.plugin.analyze_frame_for_zoom")
+    def test_single_frame_success(
+        self,
+        mock_analyze: MagicMock,
+        plugin_config: dict[str, Any],
+        tmp_path: Path,
+    ) -> None:
+        mock_analyze.return_value = (0.3, 0.7)
+        plugin = OpenAIPlugin({**plugin_config, "smart_zoom_enabled": True})
+        frames = self._make_frames(tmp_path, count=1)
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+
+        plugin.on_frames_extracted(context)
+
+        zoom_path = context.shared["smart_zoom"]["zoom_path"]
+        assert len(zoom_path.points) == 1
+        assert zoom_path.points[0].center_x == 0.3
+        assert zoom_path.points[0].center_y == 0.7
+        assert zoom_path.points[0].timestamp == 0.0
+        assert zoom_path.source_width == 1920
+        assert zoom_path.source_height == 1080
+
+    @patch("reeln_openai_plugin.plugin.analyze_frame_for_zoom")
+    def test_multi_frame_success(
+        self,
+        mock_analyze: MagicMock,
+        plugin_config: dict[str, Any],
+        tmp_path: Path,
+    ) -> None:
+        mock_analyze.side_effect = [(0.3, 0.4), (0.5, 0.6), (0.7, 0.8)]
+        plugin = OpenAIPlugin({**plugin_config, "smart_zoom_enabled": True})
+        frames = self._make_frames(tmp_path, count=3)
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+
+        plugin.on_frames_extracted(context)
+
+        zoom_path = context.shared["smart_zoom"]["zoom_path"]
+        assert len(zoom_path.points) == 3
+        assert zoom_path.points[0].center_x == 0.3
+        assert zoom_path.points[1].center_x == 0.5
+        assert zoom_path.points[2].center_x == 0.7
+        assert zoom_path.duration == 10.0
+
+    @patch("reeln_openai_plugin.plugin.analyze_frame_for_zoom")
+    def test_per_frame_fallback(
+        self,
+        mock_analyze: MagicMock,
+        plugin_config: dict[str, Any],
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """One frame fails, others succeed — fallback on failed frame."""
+        from reeln_openai_plugin.client import OpenAIError
+
+        mock_analyze.side_effect = [
+            (0.3, 0.4),
+            OpenAIError("API down"),
+            (0.7, 0.8),
+        ]
+        plugin = OpenAIPlugin({**plugin_config, "smart_zoom_enabled": True})
+        frames = self._make_frames(tmp_path, count=3)
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            plugin.on_frames_extracted(context)
+
+        zoom_path = context.shared["smart_zoom"]["zoom_path"]
+        assert len(zoom_path.points) == 3
+        # Failed frame gets fallback center
+        assert zoom_path.points[1].center_x == 0.5
+        assert zoom_path.points[1].center_y == 0.5
+        assert "using fallback" in caplog.text
+
+    @patch("reeln_openai_plugin.plugin.analyze_frame_for_zoom")
+    def test_all_frames_fail_no_write(
+        self,
+        mock_analyze: MagicMock,
+        plugin_config: dict[str, Any],
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from reeln_openai_plugin.client import OpenAIError
+
+        mock_analyze.side_effect = OpenAIError("API down")
+        plugin = OpenAIPlugin({**plugin_config, "smart_zoom_enabled": True})
+        frames = self._make_frames(tmp_path, count=2)
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            plugin.on_frames_extracted(context)
+
+        assert "smart_zoom" not in context.shared
+        assert "all 2 frame analyses failed" in caplog.text
+
+    @patch("reeln_openai_plugin.plugin.analyze_frame_for_zoom")
+    def test_model_override(
+        self,
+        mock_analyze: MagicMock,
+        plugin_config: dict[str, Any],
+        tmp_path: Path,
+    ) -> None:
+        mock_analyze.return_value = (0.5, 0.5)
+        config = {**plugin_config, "smart_zoom_enabled": True, "smart_zoom_model": "gpt-5"}
+        plugin = OpenAIPlugin(config)
+        frames = self._make_frames(tmp_path, count=1)
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+
+        plugin.on_frames_extracted(context)
+
+        call_kwargs = mock_analyze.call_args[1]
+        assert call_kwargs["model"] == "gpt-5"
+
+
+# ------------------------------------------------------------------
+# on_frames_extracted — frame description
+# ------------------------------------------------------------------
+
+
+class TestOnFramesExtractedFrameDescription:
+    def _make_frames(self, tmp_path: Path, count: int = 3) -> FakeExtractedFrames:
+        paths = []
+        timestamps = []
+        for i in range(count):
+            p = tmp_path / f"frame_{i:04d}.png"
+            p.write_bytes(b"\x89PNG")
+            paths.append(p)
+            timestamps.append(float(i * 2))
+        return FakeExtractedFrames(
+            frame_paths=tuple(paths),
+            timestamps=tuple(timestamps),
+        )
+
+    def test_disabled_skips(self, plugin_config: dict[str, Any]) -> None:
+        plugin = OpenAIPlugin({**plugin_config, "frame_description_enabled": False})
+        frames = FakeExtractedFrames()
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+        plugin.on_frames_extracted(context)
+        assert "frame_descriptions" not in context.shared
+
+    @patch("reeln_openai_plugin.plugin.describe_frames")
+    def test_success_writes_shared_and_caches(
+        self,
+        mock_describe: MagicMock,
+        plugin_config: dict[str, Any],
+        tmp_path: Path,
+    ) -> None:
+        from reeln_openai_plugin.frames import FrameDescriptions
+
+        mock_describe.return_value = FrameDescriptions(
+            descriptions=("Player shoots", "Goal scored"),
+            summary="Quick wrist shot goal",
+        )
+        config = {**plugin_config, "frame_description_enabled": True}
+        plugin = OpenAIPlugin(config)
+        frames = self._make_frames(tmp_path, count=2)
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+
+        plugin.on_frames_extracted(context)
+
+        # Written to shared context
+        fd = context.shared["frame_descriptions"]
+        assert fd["descriptions"] == ["Player shoots", "Goal scored"]
+        assert fd["summary"] == "Quick wrist shot goal"
+        # Cached on instance
+        assert plugin._frame_descriptions is not None
+        assert plugin._frame_descriptions.summary == "Quick wrist shot goal"
+
+    @patch("reeln_openai_plugin.plugin.describe_frames")
+    def test_failure_non_fatal(
+        self,
+        mock_describe: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+        plugin_config: dict[str, Any],
+        tmp_path: Path,
+    ) -> None:
+        from reeln_openai_plugin.client import OpenAIError
+
+        mock_describe.side_effect = OpenAIError("Vision API down")
+        config = {**plugin_config, "frame_description_enabled": True}
+        plugin = OpenAIPlugin(config)
+        frames = self._make_frames(tmp_path, count=1)
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            plugin.on_frames_extracted(context)
+
+        assert "frame description failed" in caplog.text
+        assert "frame_descriptions" not in context.shared
+        assert plugin._frame_descriptions is None
+
+    @patch("reeln_openai_plugin.plugin.analyze_frame_for_zoom")
+    @patch("reeln_openai_plugin.plugin.describe_frames")
+    def test_failure_non_fatal_zoom_still_works(
+        self,
+        mock_describe: MagicMock,
+        mock_analyze: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+        plugin_config: dict[str, Any],
+        tmp_path: Path,
+    ) -> None:
+        from reeln_openai_plugin.client import OpenAIError
+
+        mock_analyze.return_value = (0.3, 0.7)
+        mock_describe.side_effect = OpenAIError("Vision API down")
+        config = {
+            **plugin_config,
+            "smart_zoom_enabled": True,
+            "frame_description_enabled": True,
+        }
+        plugin = OpenAIPlugin(config)
+        frames = self._make_frames(tmp_path, count=1)
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            plugin.on_frames_extracted(context)
+
+        # Zoom still works
+        assert "smart_zoom" in context.shared
+        zoom_path = context.shared["smart_zoom"]["zoom_path"]
+        assert zoom_path.points[0].center_x == 0.3
+        # Frame description failed gracefully
+        assert "frame_descriptions" not in context.shared
+        assert "frame description failed" in caplog.text
+
+    @patch("reeln_openai_plugin.plugin.describe_frames")
+    def test_model_override(
+        self,
+        mock_describe: MagicMock,
+        plugin_config: dict[str, Any],
+        tmp_path: Path,
+    ) -> None:
+        from reeln_openai_plugin.frames import FrameDescriptions
+
+        mock_describe.return_value = FrameDescriptions(
+            descriptions=("d",), summary="s",
+        )
+        config = {
+            **plugin_config,
+            "frame_description_enabled": True,
+            "frame_description_model": "gpt-5",
+        }
+        plugin = OpenAIPlugin(config)
+        frames = self._make_frames(tmp_path, count=1)
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+
+        plugin.on_frames_extracted(context)
+
+        call_kwargs = mock_describe.call_args[1]
+        assert call_kwargs["model"] == "gpt-5"
+
+    @patch("reeln_openai_plugin.plugin.describe_frames")
+    def test_only_frame_description_enabled(
+        self,
+        mock_describe: MagicMock,
+        plugin_config: dict[str, Any],
+        tmp_path: Path,
+    ) -> None:
+        """Frame description works even when smart zoom is disabled."""
+        from reeln_openai_plugin.frames import FrameDescriptions
+
+        mock_describe.return_value = FrameDescriptions(
+            descriptions=("action",), summary="play summary",
+        )
+        config = {
+            **plugin_config,
+            "smart_zoom_enabled": False,
+            "frame_description_enabled": True,
+        }
+        plugin = OpenAIPlugin(config)
+        frames = self._make_frames(tmp_path, count=1)
+        context = HookContext(
+            hook=Hook.ON_FRAMES_EXTRACTED,
+            data={"frames": frames},
+        )
+
+        plugin.on_frames_extracted(context)
+
+        assert "frame_descriptions" in context.shared
+        assert "smart_zoom" not in context.shared
+
+
+# ------------------------------------------------------------------
+# on_post_render — frame description integration
+# ------------------------------------------------------------------
+
+
+class TestOnPostRenderFrameDescription:
+    @patch("reeln_openai_plugin.plugin.generate_short_metadata")
+    def test_frame_summary_passed_to_metadata(
+        self,
+        mock_gen: MagicMock,
+        plugin_config: dict[str, Any],
+    ) -> None:
+        from reeln_openai_plugin.frames import FrameDescriptions
+        from reeln_openai_plugin.short_metadata import ShortMetadata
+
+        mock_gen.return_value = ShortMetadata(title="T", description="D")
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": True})
+        plugin._game_info = FakeGameInfo()
+        plugin._frame_descriptions = FrameDescriptions(
+            descriptions=("shot", "goal"),
+            summary="Wrist shot goal",
+        )
+
+        plan = MagicMock()
+        plan.filter_complex = "filter"
+        plan.output = MagicMock()
+        plan.output.stem = "clip"
+        context = HookContext(hook=Hook.POST_RENDER, data={"plan": plan, "result": MagicMock()})
+
+        plugin.on_post_render(context)
+
+        call_kwargs = mock_gen.call_args[1]
+        assert call_kwargs["frame_summary"] == "Wrist shot goal"
+
+    @patch("reeln_openai_plugin.plugin.generate_short_metadata")
+    def test_frame_descriptions_cleared_after_use(
+        self,
+        mock_gen: MagicMock,
+        plugin_config: dict[str, Any],
+    ) -> None:
+        from reeln_openai_plugin.frames import FrameDescriptions
+        from reeln_openai_plugin.short_metadata import ShortMetadata
+
+        mock_gen.return_value = ShortMetadata(title="T", description="D")
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": True})
+        plugin._game_info = FakeGameInfo()
+        plugin._frame_descriptions = FrameDescriptions(
+            descriptions=("d",), summary="s",
+        )
+
+        plan = MagicMock()
+        plan.filter_complex = "filter"
+        plan.output = MagicMock()
+        plan.output.stem = "clip"
+        context = HookContext(hook=Hook.POST_RENDER, data={"plan": plan, "result": MagicMock()})
+
+        plugin.on_post_render(context)
+
+        assert plugin._frame_descriptions is None
+
+    @patch("reeln_openai_plugin.plugin.generate_short_metadata")
+    def test_no_frame_descriptions_empty_summary(
+        self,
+        mock_gen: MagicMock,
+        plugin_config: dict[str, Any],
+    ) -> None:
+        from reeln_openai_plugin.short_metadata import ShortMetadata
+
+        mock_gen.return_value = ShortMetadata(title="T", description="D")
+        plugin = OpenAIPlugin({**plugin_config, "short_metadata_enabled": True})
+        plugin._game_info = FakeGameInfo()
+        assert plugin._frame_descriptions is None
+
+        plan = MagicMock()
+        plan.filter_complex = "filter"
+        plan.output = MagicMock()
+        plan.output.stem = "clip"
+        context = HookContext(hook=Hook.POST_RENDER, data={"plan": plan, "result": MagicMock()})
+
+        plugin.on_post_render(context)
+
+        call_kwargs = mock_gen.call_args[1]
+        assert call_kwargs["frame_summary"] == ""
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/test_short_metadata.py
+++ b/tests/unit/test_short_metadata.py
@@ -1,0 +1,202 @@
+"""Tests for short metadata generation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from reeln_openai_plugin.client import OpenAIError
+from reeln_openai_plugin.prompts import PromptRegistry
+from reeln_openai_plugin.short_metadata import (
+    SHORT_SCHEMA,
+    ShortMetadata,
+    generate_short_metadata,
+)
+from tests.conftest import FakeGameInfo
+
+# ------------------------------------------------------------------
+# ShortMetadata
+# ------------------------------------------------------------------
+
+
+class TestShortMetadata:
+    def test_frozen(self) -> None:
+        m = ShortMetadata(title="T", description="D")
+        with pytest.raises(AttributeError):
+            m.title = "X"  # type: ignore[misc]
+
+    def test_fields(self) -> None:
+        m = ShortMetadata(title="T", description="D")
+        assert m.title == "T"
+        assert m.description == "D"
+
+
+# ------------------------------------------------------------------
+# SHORT_SCHEMA
+# ------------------------------------------------------------------
+
+
+class TestShortSchema:
+    def test_required_fields(self) -> None:
+        assert set(SHORT_SCHEMA["required"]) == {"title", "description"}
+
+    def test_no_additional_properties(self) -> None:
+        assert SHORT_SCHEMA["additionalProperties"] is False
+
+
+# ------------------------------------------------------------------
+# generate_short_metadata
+# ------------------------------------------------------------------
+
+
+class TestGenerateShortMetadata:
+    def test_success(self) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "title": "Eagles vs Hawks Goal Highlight",
+            "description": "Amazing goal in the Eagles vs Hawks game!",
+        }
+        registry = PromptRegistry()
+        info = FakeGameInfo()
+
+        result = generate_short_metadata(client, registry, info)
+
+        assert isinstance(result, ShortMetadata)
+        assert result.title == "Eagles vs Hawks Goal Highlight"
+        assert result.description == "Amazing goal in the Eagles vs Hawks game!"
+        client.request_structured.assert_called_once()
+
+        call_kwargs = client.request_structured.call_args[1]
+        assert call_kwargs["schema_name"] == "short"
+
+    def test_with_clip_name(self) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "title": "Short Title",
+            "description": "Short Desc",
+        }
+        registry = PromptRegistry()
+        info = FakeGameInfo()
+
+        result = generate_short_metadata(
+            client, registry, info, clip_name="goal_001",
+        )
+
+        assert result.title == "Short Title"
+        call_kwargs = client.request_structured.call_args[1]
+        assert "goal_001" in call_kwargs["prompt"]
+
+    def test_without_clip_name(self) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "title": "Title",
+            "description": "Desc",
+        }
+        registry = PromptRegistry()
+        info = FakeGameInfo()
+
+        result = generate_short_metadata(client, registry, info)
+
+        assert result.title == "Title"
+        # clip_name placeholder should remain unrendered
+        call_kwargs = client.request_structured.call_args[1]
+        assert "{{clip_name}}" in call_kwargs["prompt"]
+
+    def test_api_error_propagates(self) -> None:
+        client = MagicMock()
+        client.request_structured.side_effect = OpenAIError("API down")
+        registry = PromptRegistry()
+        info = FakeGameInfo()
+
+        with pytest.raises(OpenAIError, match="API down"):
+            generate_short_metadata(client, registry, info)
+
+    def test_with_frame_summary(self) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "title": "Amazing Goal!",
+            "description": "Player scores top corner.",
+        }
+        registry = PromptRegistry()
+        info = FakeGameInfo()
+
+        result = generate_short_metadata(
+            client, registry, info, frame_summary="Wrist shot finds the net",
+        )
+
+        assert result.title == "Amazing Goal!"
+        call_kwargs = client.request_structured.call_args[1]
+        assert "Wrist shot finds the net" in call_kwargs["prompt"]
+
+    def test_without_frame_summary(self) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "title": "T",
+            "description": "D",
+        }
+        registry = PromptRegistry()
+        info = FakeGameInfo()
+
+        result = generate_short_metadata(client, registry, info)
+
+        assert result.title == "T"
+        # frame_summary placeholder should remain unrendered
+        call_kwargs = client.request_structured.call_args[1]
+        assert "{{frame_summary}}" in call_kwargs["prompt"]
+
+    def test_uses_game_info_variables(self) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "title": "T",
+            "description": "D",
+        }
+        registry = PromptRegistry()
+        info = FakeGameInfo(home_team="Storm", away_team="Thunder", sport="hockey")
+
+        generate_short_metadata(client, registry, info)
+
+        call_kwargs = client.request_structured.call_args[1]
+        assert "Storm" in call_kwargs["prompt"]
+        assert "Thunder" in call_kwargs["prompt"]
+        assert "hockey" in call_kwargs["prompt"]
+
+    def test_with_player_and_assists(self) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "title": "#48 Remitz Scores!",
+            "description": "Great play.",
+        }
+        registry = PromptRegistry()
+        info = FakeGameInfo()
+
+        result = generate_short_metadata(
+            client, registry, info,
+            player="#48 Benjamin Remitz",
+            assists="#7 John Smith, #22 Jane Doe",
+        )
+
+        assert result.title == "#48 Remitz Scores!"
+        call_kwargs = client.request_structured.call_args[1]
+        assert "#48 Benjamin Remitz" in call_kwargs["prompt"]
+        assert "#7 John Smith, #22 Jane Doe" in call_kwargs["prompt"]
+
+    def test_with_event_type_and_level(self) -> None:
+        client = MagicMock()
+        client.request_structured.return_value = {
+            "title": "Goal!",
+            "description": "Desc.",
+        }
+        registry = PromptRegistry()
+        info = FakeGameInfo()
+
+        result = generate_short_metadata(
+            client, registry, info,
+            event_type="goal",
+            level="2016",
+        )
+
+        assert result.title == "Goal!"
+        call_kwargs = client.request_structured.call_args[1]
+        assert "goal" in call_kwargs["prompt"]
+        assert "2016" in call_kwargs["prompt"]

--- a/tests/unit/test_translate.py
+++ b/tests/unit/test_translate.py
@@ -64,7 +64,10 @@ class TestTranslateBatch:
         registry = PromptRegistry()
 
         result = translate_metadata(
-            client, registry, "Title", "Desc",
+            client,
+            registry,
+            "Title",
+            "Desc",
             languages={"fi": "Finnish", "sv": "Swedish"},
         )
 
@@ -84,7 +87,10 @@ class TestTranslateBatch:
         registry = PromptRegistry()
 
         result = translate_metadata(
-            client, registry, "Title", "Desc",
+            client,
+            registry,
+            "Title",
+            "Desc",
             languages={"fi": "Finnish"},
         )
 
@@ -115,7 +121,10 @@ class TestTranslatePerLanguage:
         registry = PromptRegistry()
 
         result = translate_metadata(
-            client, registry, "Title", "Desc",
+            client,
+            registry,
+            "Title",
+            "Desc",
             languages={"fi": "Finnish", "sv": "Swedish"},
             per_language_prompts={"fi": "translate_single", "sv": "translate_single"},
         )
@@ -135,7 +144,10 @@ class TestTranslatePerLanguage:
 
         with caplog.at_level(logging.WARNING):
             result = translate_metadata(
-                client, registry, "Title", "Desc",
+                client,
+                registry,
+                "Title",
+                "Desc",
                 languages={"fi": "Finnish", "sv": "Swedish"},
                 per_language_prompts={"fi": "translate_single", "sv": "translate_single"},
             )
@@ -151,7 +163,10 @@ class TestTranslatePerLanguage:
         registry = PromptRegistry()
 
         result = translate_metadata(
-            client, registry, "Title", "Desc",
+            client,
+            registry,
+            "Title",
+            "Desc",
             languages={"fi": "Finnish"},
             per_language_prompts={"sv": "custom_sv_prompt"},
         )
@@ -166,7 +181,10 @@ class TestTranslatePerLanguage:
 
         with caplog.at_level(logging.WARNING):
             result = translate_metadata(
-                client, registry, "Title", "Desc",
+                client,
+                registry,
+                "Title",
+                "Desc",
                 languages={"fi": "Finnish"},
                 per_language_prompts={"fi": "translate_single"},
             )
@@ -187,7 +205,10 @@ class TestModeSelection:
         registry = PromptRegistry()
 
         translate_metadata(
-            client, registry, "Title", "Desc",
+            client,
+            registry,
+            "Title",
+            "Desc",
             languages={"fi": "Finnish"},
             per_language_prompts=None,
         )
@@ -202,7 +223,10 @@ class TestModeSelection:
         registry = PromptRegistry()
 
         translate_metadata(
-            client, registry, "Title", "Desc",
+            client,
+            registry,
+            "Title",
+            "Desc",
             languages={"fi": "Finnish"},
             per_language_prompts={"fi": "translate_single"},
         )

--- a/tests/unit/test_zoom.py
+++ b/tests/unit/test_zoom.py
@@ -1,0 +1,184 @@
+"""Tests for the smart zoom module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from reeln_openai_plugin.client import OpenAIError
+from reeln_openai_plugin.zoom import (
+    FALLBACK_CENTER,
+    ZOOM_SCHEMA,
+    _clamp,
+    _encode_frame,
+    analyze_frame_for_zoom,
+)
+
+# ------------------------------------------------------------------
+# _clamp
+# ------------------------------------------------------------------
+
+
+class TestClamp:
+    def test_within_range(self) -> None:
+        assert _clamp(0.5) == 0.5
+
+    def test_below_low(self) -> None:
+        assert _clamp(-0.3) == 0.0
+
+    def test_above_high(self) -> None:
+        assert _clamp(1.7) == 1.0
+
+    def test_exact_low(self) -> None:
+        assert _clamp(0.0) == 0.0
+
+    def test_exact_high(self) -> None:
+        assert _clamp(1.0) == 1.0
+
+    def test_custom_range(self) -> None:
+        assert _clamp(5.0, low=2.0, high=4.0) == 4.0
+        assert _clamp(1.0, low=2.0, high=4.0) == 2.0
+
+
+# ------------------------------------------------------------------
+# _encode_frame
+# ------------------------------------------------------------------
+
+
+class TestEncodeFrame:
+    def test_success(self, tmp_path: Path) -> None:
+        frame = tmp_path / "frame.png"
+        frame.write_bytes(b"\x89PNG")
+        result = _encode_frame(frame)
+        assert isinstance(result, str)
+        import base64
+
+        assert base64.b64decode(result) == b"\x89PNG"
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(OpenAIError, match="Cannot read frame file"):
+            _encode_frame(tmp_path / "missing.png")
+
+
+# ------------------------------------------------------------------
+# ZOOM_SCHEMA
+# ------------------------------------------------------------------
+
+
+class TestZoomSchema:
+    def test_structure(self) -> None:
+        assert ZOOM_SCHEMA["type"] == "object"
+        assert "center_x" in ZOOM_SCHEMA["properties"]
+        assert "center_y" in ZOOM_SCHEMA["properties"]
+        assert ZOOM_SCHEMA["additionalProperties"] is False
+
+    def test_required_fields(self) -> None:
+        assert set(ZOOM_SCHEMA["required"]) == {"center_x", "center_y"}
+
+
+# ------------------------------------------------------------------
+# FALLBACK_CENTER
+# ------------------------------------------------------------------
+
+
+class TestFallbackCenter:
+    def test_value(self) -> None:
+        assert FALLBACK_CENTER == (0.5, 0.5)
+
+
+# ------------------------------------------------------------------
+# analyze_frame_for_zoom
+# ------------------------------------------------------------------
+
+
+class TestAnalyzeFrameForZoom:
+    def test_success(self, tmp_path: Path) -> None:
+        frame = tmp_path / "frame.png"
+        frame.write_bytes(b"\x89PNG")
+
+        client = MagicMock()
+        client.request_structured.return_value = {"center_x": 0.3, "center_y": 0.7}
+        registry = MagicMock()
+
+        result = analyze_frame_for_zoom(client, registry, frame)
+
+        assert result == (0.3, 0.7)
+        client.request_structured.assert_called_once()
+        call_kwargs = client.request_structured.call_args
+        assert call_kwargs[1]["images"] is not None
+        assert len(call_kwargs[1]["images"]) == 1
+        assert call_kwargs[1]["model_override"] == "gpt-4.1"
+
+    def test_clamping(self, tmp_path: Path) -> None:
+        frame = tmp_path / "frame.png"
+        frame.write_bytes(b"\x89PNG")
+
+        client = MagicMock()
+        client.request_structured.return_value = {"center_x": -0.5, "center_y": 1.8}
+        registry = MagicMock()
+
+        result = analyze_frame_for_zoom(client, registry, frame)
+
+        assert result == (0.0, 1.0)
+
+    def test_api_error_propagates(self, tmp_path: Path) -> None:
+        frame = tmp_path / "frame.png"
+        frame.write_bytes(b"\x89PNG")
+
+        client = MagicMock()
+        client.request_structured.side_effect = OpenAIError("API down")
+        registry = MagicMock()
+
+        with pytest.raises(OpenAIError, match="API down"):
+            analyze_frame_for_zoom(client, registry, frame)
+
+    def test_model_override_passed(self, tmp_path: Path) -> None:
+        frame = tmp_path / "frame.png"
+        frame.write_bytes(b"\x89PNG")
+
+        client = MagicMock()
+        client.request_structured.return_value = {"center_x": 0.5, "center_y": 0.5}
+        registry = MagicMock()
+
+        analyze_frame_for_zoom(client, registry, frame, model="gpt-5")
+
+        call_kwargs = client.request_structured.call_args[1]
+        assert call_kwargs["model_override"] == "gpt-5"
+
+    def test_encode_failure_propagates(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        registry = MagicMock()
+
+        with pytest.raises(OpenAIError, match="Cannot read frame file"):
+            analyze_frame_for_zoom(client, registry, tmp_path / "missing.png")
+
+    def test_prompt_rendered(self, tmp_path: Path) -> None:
+        frame = tmp_path / "frame.png"
+        frame.write_bytes(b"\x89PNG")
+
+        client = MagicMock()
+        client.request_structured.return_value = {"center_x": 0.5, "center_y": 0.5}
+        registry = MagicMock()
+        registry.render.return_value = "custom prompt"
+
+        analyze_frame_for_zoom(client, registry, frame)
+
+        registry.render.assert_called_once_with("smart_zoom_detect")
+        # First positional arg to request_structured should be the rendered prompt
+        assert client.request_structured.call_args[0][0] == "custom prompt"
+
+    def test_schema_passed(self, tmp_path: Path) -> None:
+        frame = tmp_path / "frame.png"
+        frame.write_bytes(b"\x89PNG")
+
+        client = MagicMock()
+        client.request_structured.return_value = {"center_x": 0.5, "center_y": 0.5}
+        registry = MagicMock()
+
+        analyze_frame_for_zoom(client, registry, frame)
+
+        call_args = client.request_structured.call_args[0]
+        assert call_args[1] is ZOOM_SCHEMA
+        assert call_args[2] == "smart_zoom_detect"


### PR DESCRIPTION
## Summary

- **v0.5.0 — Smart zoom** (`zoom.py`): Per-frame OpenAI vision analysis for dynamic crop panning, with fallback to center on failure. Writes `ZoomPath` to `context.shared["smart_zoom"]`.
- **v0.6.0 — Short metadata + frame descriptions** (`short_metadata.py`, `frames.py`): LLM-generated title/description for short uploads via `POST_RENDER` hook. Frame description sends all extracted frames in a single vision call, caches play-by-play summary on plugin instance, and feeds `{{frame_summary}}` into short metadata prompts.
- **v0.7.0 — Player/event context**: Player name, assists, event type, and team level from `POST_RENDER` hook data passed as `{{player}}`, `{{assists}}`, `{{event}}`, `{{team_level}}` template variables for richer AI-generated metadata.

### New modules
- `zoom.py` — `analyze_frame_for_zoom()`, `_encode_frame()`
- `short_metadata.py` — `generate_short_metadata()`, `ShortMetadata`
- `frames.py` — `describe_frames()`, `FrameDescriptions`

### New config fields
- `smart_zoom_enabled`, `smart_zoom_model`
- `short_metadata_enabled`
- `frame_description_enabled`, `frame_description_model`

### New prompt templates
- `smart_zoom_detect`, `short_title`, `short_description`, `frame_describe`

### Stats
- 22 files changed, +2365 lines
- 226 tests, 100% line + branch coverage

## Test plan

- [x] `make check` passes (lint, mypy strict, 100% coverage)
- [x] Manual test: installed into reeln-cli venv, rendered shorts with `frame_description_enabled: true`
- [x] Verify frame descriptions appear in shared context
- [x] Verify short metadata prompts include `{{frame_summary}}`, `{{player}}`, `{{event}}`
- [ ] Verify PyPI release triggered by `v0.7.0` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)