### PR TITLE
ci: enable Sigstore attestations for PyPI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     environment: release
     permissions:
       id-token: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v4
@@ -45,3 +46,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true


### PR DESCRIPTION
## Summary
- Add `attestations: true` to `pypa/gh-action-pypi-publish`
- Add `attestations: write` permission for Sigstore provenance generation
- Each future PyPI release will include verifiable attestations tied to the GitHub Actions workflow

## Test plan
- [ ] Next tag-triggered release generates attestations on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)